### PR TITLE
fix: setuptools v70 removed packaging from pkg_resources

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -15,8 +15,12 @@ function getOption(pluginConfig, option) {
  */
 async function normalizeVersion(version) {
   const { stdout } = await execa('python3', [
+    '-W',
+    'ignore',
     '-c',
-    'import pkg_resources\n' + `print(pkg_resources.packaging.version.Version('${version}'))`
+    'try: import packaging.version\n' +
+    'except: from pkg_resources import packaging\n' +
+    `print(packaging.version.Version('${version}'))`
   ])
 
   return stdout


### PR DESCRIPTION
- **What kind of change does this PR introduce?**

This PR adds support for setuptools v70+, as it dropped `packaging`: https://github.com/pypa/setuptools/issues/4385

- **What is the current behavior?**

```
[3:03:49 PM] [semantic-release] › ✘  An error occurred while running semantic-release: Error: Command failed with exit code 1: python3 -c import pkg_resources
print(pkg_resources.packaging.version.Version('1.30.8'))
<string>:1: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
Traceback (most recent call last):
  File "<string>", line 2, in <module>
AttributeError: module 'pkg_resources' has no attribute 'packaging'
    at makeError (/app/node_modules/@unimonkiez/semantic-release-python/node_modules/execa/lib/error.js:59:11)
    at handlePromise (/app/node_modules/@unimonkiez/semantic-release-python/node_modules/execa/index.js:114:26)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async normalizeVersion (/app/node_modules/@unimonkiez/semantic-release-python/lib/util.js:17:22)
    at async preparePoetry (/app/node_modules/@unimonkiez/semantic-release-python/lib/prepare.js:75:19)
    at async prepare (/app/node_modules/@unimonkiez/semantic-release-python/lib/prepare.js:97:7)
    at async validator (file:///app/node_modules/semantic-release/lib/plugins/normalize.js:36:24)
    at async file:///app/node_modules/semantic-release/lib/plugins/pipeline.js:38:36
    at async Promise.all (index 0)
    at async next (file:///app/node_modules/semantic-release/node_modules/p-reduce/index.js:15:44) {
  shortMessage: 'Command failed with exit code 1: python3 -c import pkg_resources\n' +
    "print(pkg_resources.packaging.version.Version('1.30.8'))",
  command: 'python3 -c import pkg_resources\n' +
    "print(pkg_resources.packaging.version.Version('1.30.8'))",
  exitCode: 1,
  signal: undefined,
  signalDescription: undefined,
  stdout: '',
  stderr: '<string>:1: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html\n' +
    'Traceback (most recent call last):\n' +
    '  File "<string>", line 2, in <module>\n' +
    "AttributeError: module 'pkg_resources' has no attribute 'packaging'",
  failed: true,
  timedOut: [secure],
  isCanceled: [secure],
  killed: [secure],
  pluginName: '@unimonkiez/semantic-release-python'
}
```

- **What is the new behavior (if this is a feature change)?**

The plugin now tries to import `packaging` directly and falls back on the old behavior if the package is not installed in the execution context.

Also, deprecation warnings when importing `pkg_resources` on newer versions are ignored as they pollute the standard output.

- **Other information**:

Submitted this here as it seems more active than upstream 
https://github.com/megabyte-labs/semantic-release-python which moved to 
https://github.com/ProfessorManhattan/semantic-release-python then to
https://gitlab.com/megabyte-labs/npm/archive/semantic-release-python
which is explicitly archived now :sweat_smile:

In the meantime, I published these changes from [my own fork](https://github.com/pdecat/semantic-release-python/tree/dev) at https://www.npmjs.com/package/@pdecat/semantic-release-python/v/2.5.37.